### PR TITLE
QOL : Add Spell Names to the Icons

### DIFF
--- a/GridSpellbook.lua
+++ b/GridSpellbook.lua
@@ -1,13 +1,11 @@
 local X_OFFSET = 50;
 local Y_OFFSET = -14;
-
 local function MakeSpellButton(i)
     local name = "SpellButton" .. i;
     local button = CreateFrame("CheckButton", name, SpellBookFrame, "SpellButtonTemplate");
     button:SetID(i);
     return button
 end
-
 local function GetSpellButton(i)
     local button = getglobal("SpellButton" .. i);
     if button == nil then
@@ -15,21 +13,29 @@ local function GetSpellButton(i)
     end
     return button;
 end
-
 local function MakeRankString(i)
     local button = getglobal("SpellButton" .. i);
-    local rankString = button:CreateFontString("SpellButton" .. i .. "RankText", "ARTWORK", "NumberFontNormalSmallGray");
+    local rankString = button:CreateFontString("SpellButton" .. i .. "RankText", "ARTWORK");
+    rankString:SetFont("Fonts\\FRIZQT__.TTF", 10, "OUTLINE");
     rankString:SetJustifyH("RIGHT");
-    rankString:SetPoint("TOPLEFT", button, "TOPLEFT", -2, -2);
+    rankString:SetPoint("TOPLEFT", button, "TOPLEFT", -2, -3);
     rankString:SetWidth(36);
     rankString:SetHeight(10);
 end
-
+local function MakeSpellNameString(i)
+    local button = getglobal("SpellButton" .. i);
+    local spellNameString = button:CreateFontString("SpellButton" .. i .. "SpellNameText", "ARTWORK");
+    spellNameString:SetFont("Fonts\\FRIZQT__.TTF", 8, "OUTLINE");
+    spellNameString:SetJustifyH("CENTER");
+    spellNameString:SetPoint("BOTTOMLEFT", button);
+    spellNameString:SetWidth(36);
+    spellNameString:SetHeight(16);
+    spellNameString:SetNonSpaceWrap(true); -- Auto Wrap, not perfect but get the job done
+end
 local function PuntOffScreen(widget)
     -- Hide() and SetAlpha(0) were insufficient, so...
     widget:SetPoint("TOPLEFT", UIParent, "TOPLEFT", 0, 5000);
 end
-
 local function SetupGrid()
     -- Player spell list assumes 2 columns for putting similar spells in the same column
     --    e.g. at indices 1, 3, 5
@@ -42,6 +48,7 @@ local function SetupGrid()
                 PuntOffScreen(getglobal("SpellButton" .. i .. "SpellName"));
                 PuntOffScreen(getglobal("SpellButton" .. i .. "SubSpellName"));
                 MakeRankString(i);
+                MakeSpellNameString(i);
                 if i == 1 then
                     -- Leave first button in place
                 elseif row == 1 and column == 1 then
@@ -57,7 +64,6 @@ local function SetupGrid()
     end
     SPELLS_PER_PAGE = i - 1; -- Update for SpellBookFrame.lua
 end
-
 -- Hook to update rank text
 local Original_SpellButton_UpdateButton = SpellButton_UpdateButton;
 function SpellButton_UpdateButton()
@@ -68,21 +74,36 @@ function SpellButton_UpdateButton()
 	local name = this:GetName();
 	local rankString = getglobal(name.."RankText");
 	local subSpellString = getglobal(name.."SubSpellName");
+	local spellNameString = getglobal(name.."SpellNameText");
+	
     if not subSpellString:IsVisible() then
         rankString:Hide();
+        spellNameString:Hide();
         return;
     end
-
-    local subSpellName = subSpellString:GetText();
     
+    local subSpellName = subSpellString:GetText();
     if subSpellName ~= nil and string.find(subSpellName, "Rank ") ~= nil then
         rankString:SetText(string.sub(subSpellName, 6));
         rankString:Show();
     else
         rankString:Hide();
     end
+    
+    local id = SpellBook_GetSpellID(this:GetID());
+    local spellName, _ = GetSpellName(id, SpellBookFrame.bookType);
+    if spellName and spellNameString then
+        -- Troncate if too long
+        local displayName = spellName;
+        if string.len(displayName) > 15 then
+            displayName = string.sub(displayName, 1, 15) .. "..";
+        end
+        spellNameString:SetText(displayName);
+        spellNameString:Show();
+    else
+        spellNameString:Hide();
+    end
 end
-
 -- Hook tooltip to add now-hidden subSpellName line
 local Original_SpellButton_OnEnter = SpellButton_OnEnter;
 function SpellButton_OnEnter()
@@ -94,5 +115,4 @@ function SpellButton_OnEnter()
     GameTooltipTextRight1:Show();
     GameTooltip:Show(); -- Needed to update the tooltip's size
 end
-
 SetupGrid();

--- a/GridSpellbook.lua
+++ b/GridSpellbook.lua
@@ -1,11 +1,13 @@
 local X_OFFSET = 50;
 local Y_OFFSET = -14;
+
 local function MakeSpellButton(i)
     local name = "SpellButton" .. i;
     local button = CreateFrame("CheckButton", name, SpellBookFrame, "SpellButtonTemplate");
     button:SetID(i);
     return button
 end
+
 local function GetSpellButton(i)
     local button = getglobal("SpellButton" .. i);
     if button == nil then
@@ -13,6 +15,7 @@ local function GetSpellButton(i)
     end
     return button;
 end
+
 local function MakeRankString(i)
     local button = getglobal("SpellButton" .. i);
     local rankString = button:CreateFontString("SpellButton" .. i .. "RankText", "ARTWORK");
@@ -22,6 +25,7 @@ local function MakeRankString(i)
     rankString:SetWidth(36);
     rankString:SetHeight(10);
 end
+
 local function MakeSpellNameString(i)
     local button = getglobal("SpellButton" .. i);
     local spellNameString = button:CreateFontString("SpellButton" .. i .. "SpellNameText", "ARTWORK");
@@ -32,10 +36,12 @@ local function MakeSpellNameString(i)
     spellNameString:SetHeight(16);
     spellNameString:SetNonSpaceWrap(true); -- Auto Wrap, not perfect but get the job done
 end
+
 local function PuntOffScreen(widget)
     -- Hide() and SetAlpha(0) were insufficient, so...
     widget:SetPoint("TOPLEFT", UIParent, "TOPLEFT", 0, 5000);
 end
+
 local function SetupGrid()
     -- Player spell list assumes 2 columns for putting similar spells in the same column
     --    e.g. at indices 1, 3, 5
@@ -48,7 +54,7 @@ local function SetupGrid()
                 PuntOffScreen(getglobal("SpellButton" .. i .. "SpellName"));
                 PuntOffScreen(getglobal("SpellButton" .. i .. "SubSpellName"));
                 MakeRankString(i);
-                MakeSpellNameString(i);
+                MakeSpellNameString(i); -- Ajouter le nom du sort
                 if i == 1 then
                     -- Leave first button in place
                 elseif row == 1 and column == 1 then
@@ -64,6 +70,7 @@ local function SetupGrid()
     end
     SPELLS_PER_PAGE = i - 1; -- Update for SpellBookFrame.lua
 end
+
 -- Hook to update rank text
 local Original_SpellButton_UpdateButton = SpellButton_UpdateButton;
 function SpellButton_UpdateButton()
@@ -81,7 +88,7 @@ function SpellButton_UpdateButton()
         spellNameString:Hide();
         return;
     end
-    
+
     local subSpellName = subSpellString:GetText();
     if subSpellName ~= nil and string.find(subSpellName, "Rank ") ~= nil then
         rankString:SetText(string.sub(subSpellName, 6));
@@ -89,7 +96,7 @@ function SpellButton_UpdateButton()
     else
         rankString:Hide();
     end
-    
+
     local id = SpellBook_GetSpellID(this:GetID());
     local spellName, _ = GetSpellName(id, SpellBookFrame.bookType);
     if spellName and spellNameString then
@@ -104,6 +111,7 @@ function SpellButton_UpdateButton()
         spellNameString:Hide();
     end
 end
+
 -- Hook tooltip to add now-hidden subSpellName line
 local Original_SpellButton_OnEnter = SpellButton_OnEnter;
 function SpellButton_OnEnter()
@@ -115,4 +123,5 @@ function SpellButton_OnEnter()
     GameTooltipTextRight1:Show();
     GameTooltip:Show(); -- Needed to update the tooltip's size
 end
+
 SetupGrid();

--- a/GridSpellbook.lua
+++ b/GridSpellbook.lua
@@ -54,7 +54,7 @@ local function SetupGrid()
                 PuntOffScreen(getglobal("SpellButton" .. i .. "SpellName"));
                 PuntOffScreen(getglobal("SpellButton" .. i .. "SubSpellName"));
                 MakeRankString(i);
-                MakeSpellNameString(i); -- Ajouter le nom du sort
+                MakeSpellNameString(i);
                 if i == 1 then
                     -- Leave first button in place
                 elseif row == 1 and column == 1 then
@@ -90,6 +90,7 @@ function SpellButton_UpdateButton()
     end
 
     local subSpellName = subSpellString:GetText();
+
     if subSpellName ~= nil and string.find(subSpellName, "Rank ") ~= nil then
         rankString:SetText(string.sub(subSpellName, 6));
         rankString:Show();


### PR DESCRIPTION
I've made some changes to show the spell names on the icons kind of like in the default wow UI, it's a little QOL feature but I feel like it add a lot to the addon, I use auto-wrapping which is not perfect but get the job done.

Exemple : 

<img width="497" height="576" alt="image" src="https://github.com/user-attachments/assets/948c9e12-5a21-4439-8f7c-0a4a28d20c17" />

Feel free to add it if you like it.